### PR TITLE
Make autocentering optional, with default false

### DIFF
--- a/mpl_pan_zoom/_zoom.py
+++ b/mpl_pan_zoom/_zoom.py
@@ -76,9 +76,15 @@ def zoom_factory(ax, base_scale=1.1, auto_centering: bool = False):
 
         if auto_centering:
             if np.abs(new_yrange) > np.abs(orig_yrange):
-                new_ylim = orig_center[1] - new_yrange / 2, orig_center[1] + new_yrange / 2
+                new_ylim = (
+                    orig_center[1] - new_yrange / 2,
+                    orig_center[1] + new_yrange / 2,
+                )
             if np.abs(new_xrange) > np.abs(orig_xrange):
-                new_xlim = orig_center[0] - new_xrange / 2, orig_center[0] + new_xrange / 2
+                new_xlim = (
+                    orig_center[0] - new_xrange / 2,
+                    orig_center[0] + new_xrange / 2,
+                )
 
         ax.set_xlim(new_xlim)
         ax.set_ylim(new_ylim)

--- a/mpl_pan_zoom/_zoom.py
+++ b/mpl_pan_zoom/_zoom.py
@@ -6,7 +6,7 @@ __all__ = [
 
 
 # based on https://gist.github.com/tacaswell/3144287
-def zoom_factory(ax, base_scale=1.1):
+def zoom_factory(ax, base_scale=1.1, auto_centering: bool = False):
     """
     Add ability to zoom with the scroll wheel.
 
@@ -17,6 +17,8 @@ def zoom_factory(ax, base_scale=1.1):
         axis on which to implement scroll to zoom
     base_scale : float
         how much zoom on each tick of scroll wheel
+    auto_centering: bool
+        whether to auto center zoom
 
     Returns
     -------
@@ -49,8 +51,6 @@ def zoom_factory(ax, base_scale=1.1):
         cur_xlim = ax.get_xlim()
         cur_ylim = ax.get_ylim()
         # set the range
-        (cur_xlim[1] - cur_xlim[0]) * 0.5
-        (cur_ylim[1] - cur_ylim[0]) * 0.5
         xdata = event.xdata  # get event x location
         ydata = event.ydata  # get event y location
         if event.button == "up":
@@ -74,10 +74,12 @@ def zoom_factory(ax, base_scale=1.1):
         new_yrange = limits_to_range(new_ylim)
         new_xrange = limits_to_range(new_xlim)
 
-        if np.abs(new_yrange) > np.abs(orig_yrange):
-            new_ylim = orig_center[1] - new_yrange / 2, orig_center[1] + new_yrange / 2
-        if np.abs(new_xrange) > np.abs(orig_xrange):
-            new_xlim = orig_center[0] - new_xrange / 2, orig_center[0] + new_xrange / 2
+        if auto_centering:
+            if np.abs(new_yrange) > np.abs(orig_yrange):
+                new_ylim = orig_center[1] - new_yrange / 2, orig_center[1] + new_yrange / 2
+            if np.abs(new_xrange) > np.abs(orig_xrange):
+                new_xlim = orig_center[0] - new_xrange / 2, orig_center[0] + new_xrange / 2
+
         ax.set_xlim(new_xlim)
         ax.set_ylim(new_ylim)
 


### PR DESCRIPTION
Yes, thanks for getting in touch @ianhi .  I hadn't seen this issue (https://github.com/mpl-extensions/mpl-pan-zoom/issues/7) before last week, but it is exactly the problem I was having.  I told you that I just made a fork for my current use, and my workaround was exactly what you propose in your comment above - basically to just remove lines 75-78 that do the recentering.  I can't think of a reason why I'd ever want to autocenter, but if that behavior is worth maintaining, your solution of making it an optional input with the default behavior set to False would serve both purposes.  I think this minor update is what you had in mind.  I tested it against with my application and the example code provided by [antoniovazquezblanco](https://github.com/antoniovazquezblanco) and it seems to work.  See what you think.